### PR TITLE
Needs to be box86:armhf or it downloads a package from August 2021

### DIFF
--- a/apps/Box86/install-64
+++ b/apps/Box86/install-64
@@ -35,7 +35,7 @@ echo "Adding key..."
 wget -qO- https://itai-nelken.github.io/weekly-box86-debs/debian/KEY.gpg | sudo apt-key add - || error "Failed to add key to box86 repo!"
 echo "Installing box86..."
 sudo dpkg --remove box86-no-binfmt-restart 2>/dev/null
-install_packages box86 || exit 1
+install_packages box86:armhf || exit 1
 
 if ! sudo systemctl restart systemd-binfmt ;then
   echo -e "\nWarning: systemd-binfmt failed to restart. Getting debug info..."


### PR DESCRIPTION
I'm not sure why but when apt downloads the plain box86 package on aarch64 it's downloading a rather old build of box86. It doesn't seem to be a box86:aarch64 package (that would be quite illogical), maybe it's some sort of meta package? Changing box86 to box86:armhf will make it get the latest build instead.